### PR TITLE
Usunięcie tagów typu <a id="c123"></a> dla wersji językowych

### DIFF
--- a/files/private/assets/typoscript/content/ce_layout/setup.tss
+++ b/files/private/assets/typoscript/content/ce_layout/setup.tss
@@ -78,3 +78,6 @@ tt_content.stdWrap.innerWrap.cObject {
     }
     40.30.cObject.default.value = ><div class="box">|</div></section>
 }
+
+# Usunięcie tagów typu <a id="c123"></a> dla wersji językowych
+tt_content.stdWrap.prepend >


### PR DESCRIPTION
Zmieńmy na eng.
