### PR TITLE
Update tsconfig.tsu

### DIFF
--- a/files/assets/typoscript/tsconfig_user/tsconfig.tsu
+++ b/files/assets/typoscript/tsconfig_user/tsconfig.tsu
@@ -48,7 +48,8 @@ setup {
         rteWidth = 95%
         rteHeight = 400
         rteResize = 1
-	}
+    }
+    override.edit_docModuleUpload = 1
 }
 
 


### PR DESCRIPTION
Zdarza się, że BE nie chce wyświetlić przycisku Wybierz i wczytaj pliki, mimo dobrze ustawionych folderów. Ustawienie override.edit_docModuleUpload = 1 może rozwiązać ten problem.
